### PR TITLE
Add "kyiv" to ukrainian locations.

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -9,7 +9,7 @@ var PRESETS = map[string]PresetLocations{
   "norway":PresetLocations{"norway", "norge", "oslo", "bergen"},
   "germany":PresetLocations{"germany", "deutschland", "berlin", "frankfurt", "munich", "m%C3%BCnchen", "hamburg", "cologne", "k%C3%B6ln"},
   "netherlands":PresetLocations{"netherlands", "nederland", "amsterdam", "rotterdam", "hague", "utrecht", "holland"},
-  "ukraine":PresetLocations{"ukraine", "kiev", "kharkiv", "dnipro", "odesa", "donetsk", "zaporizhia"},
+  "ukraine":PresetLocations{"ukraine", "kiev", "kyiv", "kharkiv", "dnipro", "odesa", "donetsk", "zaporizhia"},
   "japan":PresetLocations{"japan", "tokyo", "yokohama", "osaka", "nagoya", "sapporo", "kobe", "kyoto", "fukuoka", "kawasaki", "saitama", "hiroshima", "sendai"},
   "russia":PresetLocations{"russia", "moscow", "saint%2Bpetersburg", "novosibirsk", "yekaterinburg", "nizhny%2Bnovgorod", "samara", "omsk", "kazan", "chelyabinsk", "rostov-on-don", "ufa", "volgograd"},
   "estonia":PresetLocations{"estonia", "eesti", "tallinn", "tartu", "narva", "p%C3%A4rnu"},


### PR DESCRIPTION
"Kiev", it's pronunciation in Russian, and "Kyiv" is in Ukrainian.
There are a lot of both Russian and Ukrainian speaking people in Ukraine, so both variants are used.