### PR TITLE
Scale avatar images to 80px

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -88,7 +88,7 @@ func (client HttpGithubClient) SearchUsers(query UserSearchQuery) ([]User, error
             __typename
             ... on User {
               login,
-              avatarUrl,
+              avatarUrl(size: 80),
               name,
               company,
               organizations(first: 100) {


### PR DESCRIPTION
This is a companion of lauripiispanen/github-top#28.

80 instead of 40 so that images look good on high-PPI screens.

Here’s the page sizes with different scales (using the [Germany page](https://sainaen.github.io/github-top/germany.html) as an example):
* no size limit: >13 MB
* `size: 80`: 1.18 MB
* `size: 40`: 653 KB