### PR TITLE
Add a few cities to Mexico

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -29,7 +29,7 @@ var PRESETS = map[string]PresetLocations{
 	"brazil":       PresetLocations{"brazil", "brasil", "s%C3%A3o%20paulo", "bras%C3%ADlia", "salvador", "fortaleza", "belo%20horizonte", "manaus", "curitiba", "recife", "porto%20alegre"},
 	"nigeria":      PresetLocations{"nigeria", "lagos", "kano", "ibadan", "benin%20city", "port%20harcourt", "jos", "ilorin"},
 	"bangladesh":   PresetLocations{"bangladesh", "dhaka", "chittagong", "khulna", "rajshahi", "barisal", "sylhet", "rangpur", "comilla", "gazipur"},
-	"mexico":       PresetLocations{"mexico", "mexico%20city", "guadalajara", "puebla", "tijuana", "mexicali"},
+	"mexico":       PresetLocations{"mexico", "mexico%20city", "guadalajara", "puebla", "tijuana", "mexicali", "monterrey", "hermosillo", "zapopan", "ciudad%20juarez", "chihuahua", "aguascalientes", "mx"},
 	"philippines":  PresetLocations{"philippines", "pilipinas", "quezon", "manila", "davao", "caloocan", "cebu", "zamboanga", "bohol", "pasig", "bacolod", "makati", "baguio"},
 	"luxembourg":   PresetLocations{"luxembourg", "esch-sur-alzette", "differdange", "dudelange", "ettelbruck", "diekirch", "wiltz", "echternach", "rumelange", "grevenmacher", "bertrange", "mamer", "capellen", "strassen", "diekirch"},
 	"egypt":        PresetLocations{"egypt", "cairo", "alexandria", "giza", "port%2Bsaid", "suez", "luxor", "el%2Bmahalla", "asyut", "al%2Bmansurah", "tanda"},


### PR DESCRIPTION
I added a few popular cities and I also added **mx**. I don't know if a word this short could cause any problems, but there's also **uk**.

There's [many users](https://github.com/search?p=5&q=repos%3A1+location%3Amx&type=Users) that list **MX** as their location only.

Also, is this strictly for cities? Some people just list their states, so I figured it would be easier to list major states.