### PR TITLE
Add Czechia (Czech Republic alternative name)

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -309,7 +309,7 @@ var PRESETS = map[string]QueryPreset{
 		include: []string{"dominican+republic", "republica+dominicana", "santo+domingo", "la+vega", "macoris"},
 	},
 	"czech republic": QueryPreset{
-		include: []string{"czech", "ceska", "prague", "budejovice", "plzen", "karlovy", "ostrava", "brno"},
+		include: []string{"czech", "czechia", "ceska", "prague", "budejovice", "plzen", "karlovy", "ostrava", "brno"},
 	},
 	"jordan": QueryPreset{
 		include: []string{"jordan", "amman", "zarqa", "irbid"},


### PR DESCRIPTION
It's the official English short name since 2016, see https://en.wikipedia.org/wiki/Name_of_the_Czech_Republic